### PR TITLE
Accessibility Improvements

### DIFF
--- a/maplibre-control-basemapbar.css
+++ b/maplibre-control-basemapbar.css
@@ -56,3 +56,9 @@
 .maplibre-control-basemapbar:not(.maplibre-control-basemapbar-collapsed) .maplibre-control-basemapbar-expandbutton {
     display: none;
 }
+
+.maplibre-control-basemapbar button:is(:focus, :focus-visible) {
+  outline: 2px solid black;
+  outline-offset: 2px;
+  box-shadow: none !important;
+}

--- a/maplibre-control-basemapbar.js
+++ b/maplibre-control-basemapbar.js
@@ -41,16 +41,22 @@ class MapLibreControlBasemapBar {
         this.expandbutton.title = this.options.tooltipExpandButton;
         this.expandbutton.innerHTML = this.options.expandButtonText;
         this.expandbutton.setAttribute('aria-controls', buttonset.id);
-        this.expandbutton.setAttribute('aria-expanded', 'true');
         container.appendChild(this.expandbutton);
 
         this.collapsebutton = document.createElement('button');
         this.collapsebutton.type = 'button';
         this.collapsebutton.className = 'maplibre-control-basemapbar-collapsebutton';
         this.collapsebutton.title = this.options.tooltopCollapseButton;
-        this.collapsebutton.innerHTML = "&times;";
         this.collapsebutton.setAttribute('aria-controls', buttonset.id);
-        this.collapsebutton.setAttribute('aria-expanded', 'true');
+
+        // Better would be: this.collapsebutton.innerHTML = `<img src="${...}" alt="${...}" />`
+        const collapseIcon = document.createElement('span');
+        collapseIcon.innerHTML = '&times;';
+        collapseIcon.setAttribute('role', 'img');
+        collapseIcon.setAttribute('aria-label', this.options.tooltopCollapseButton);
+        
+        this.collapsebutton.appendChild(collapseIcon);
+        
         container.appendChild(this.collapsebutton);
 
         this.collapsebutton.addEventListener('click', () => {
@@ -75,17 +81,11 @@ class MapLibreControlBasemapBar {
     expandBar() {
         if (this.isExpanded()) return;
         this._container.classList.remove('maplibre-control-basemapbar-collapsed');
-
-        this.expandbutton.setAttribute('aria-expanded', 'true');
-        this.collapsebutton.setAttribute('aria-expanded', 'true');
     }
 
     collapseBar() {
         if (! this.isExpanded()) return;
         this._container.classList.add('maplibre-control-basemapbar-collapsed');
-
-        this.expandbutton.setAttribute('aria-expanded', 'false');
-        this.collapsebutton.setAttribute('aria-expanded', 'false');
     }
 
     isExpanded() {


### PR DESCRIPTION
## Review
### Buttons
- [X] The button is marked up as `<button>`.
- [ ] **⛔️ The button text describes its purpose sufficiently.** → _addressed in PR_
   -  Close button was read as "Times"
- [X] The button has a contrast of 3:1 with the background (or outline).

#### Toggle button:
- [X] State is communicated visually.
- [X] State is communicated semantically (aria-pressed).

#### Disclosure pattern:
- [X] Collapsed/expanded state is communicated visually.
- [X] Collapsed/expanded state is communicated semantically.
    - [ ] ⛔️ **Recommended: either through aria-expanded, or through text change, not both** → _addressed in PR_
- [ ] **⛔️ The expanded section is accessible along with the button.** 
    - Technically yes, but blind users don't see that the content appeared before the button and that they have to tab back
    - Different solutions possible (how to outlined in a different section)
    - Fix not included in PR because some of the solutions require design changes, best handled internally

### Interaction
- [X] Buttons can be activated by click, enter, space.
- [X] The interactive element has a focus indicator on :focus.
    - [X] WCAG 2.1 requires there is an indicator.
    - [X] Sufficient: Using the default user agent focus indicator.
    - [ ] ⛔️ **Recommended: The indicator has at least 3:1 contrast between focused and unfocused state.** → _addressed in PR_
    - [ ] ⛔️ **Recommended: The indicator has at least 3:1 contrast against the background.** → _addressed in PR_
    - [ ] ⛔️ **Recommended: The indicator is at least 2px in thickness.** → _addressed in PR_

## Changes
- Darker and thicker focus outlines. Feel free to update the color from black to something different, just make sure it matches the requirements.
- Removed `aria-expanded` since the change in text already communicates the state. Generally it's recommended to only change the `aria-expanded`, or only update the text, since both can lead to confusing scenarios.
- Changed the button label to a `<span>` with the `img` role and alt text set to the already existing close label.

## Suggested other improvements

When opening the basemap options, they're inserted before the close button. Since on opening the basemap options the focus shifts to the close button (as it should), this means that the next element in the focus order will not be the basemap options, but the next element on the page. Sighted keyboard and assistive tech users can see that they actually need to tab to the previous element, however blind users do not know this.

There are several options on how to solve this. Only pick one of these. Combining them would lead to weird experiences.

### 1. Trap the focus inside the basemap component until closed

In this case it gets treated like a mini-dialog, where if the user has reached the end of the dialog and presses tab, the next item in the focus order again becomes the first element of the dialog. The dialog can be closed with the close button (make sure to include this one in the focus-trap-component, otherwise the focus is forever trapped within the options), and optionally also escape.

To achieve this:
- Wrap all basemap options + the close button in a parent component
- Select the first and last buttons within the parent component
   - Since they're created in JS they could be added in visual order to an array instead
- If the component is expanded, start listening to keyboard events
- If `TAB` is pressed and the `document.activeElement` is the same as the last button in the list, move the keyboard focus to the first item
- If `SHIFT TAB` is pressed and the `document.activeElement` is the same as the first button in the list, move the keyboard focus to the last item
- Optional/recommended: if `ESCAPE` is pressed, close the dialog, return focus to the basemap button
- Important: stop listening to this when closing the component (through the button or keyboard)
- Important: test that after closing it `TAB` and `SHIFT TAB` still take the user to the next and previous element on the page

This would be my recommended method, since:
- `SHIFT + TAB` still takes the focus to the visually previous element, so sighted keyboard users can still navigate based on what's there visually
- `TAB` on the close button takes the focus to the first of the basemap options, matching a structure that will make more sense to blind screen reader users
- `ESCAPE` and the close button remaining part of the focus order while expanded, meaning it's easy to return to the rest of the flow

It does require more JavaScript.

### 2. Change the design and flip the components visually

Instead of making the basemap options appear on the left of the close button, make them appear on the right. This involves changing the order in the JS file, and potentially minor CSS updates to make the component look good with the new order.

If you don't want to write as much JavaScript and are ok with modifying the design, I suggest exploring what it would be like if the close button is on the left. In that case the order matches for everyone, without needing to listen to keyboard events.

### 3. Render the options after the expand button in the DOM, reverse their order with CSS

This only requires HTML (set from JS) and CSS. The options can be rendered after the basemap toggle button in the DOM, and their position can be flipped with CSS (eg. flex or grid). In this approach pressing tab on the close button will take the focus to the first element in the options list, and pressing tab on the last option in the list takes the focus to the next element on the page.

Implication is that the visual order no longer matches the focus order for sighted keyboard users, so I don't really recommend it.

